### PR TITLE
remove Qubes R4.0 legacy support code

### DIFF
--- a/qubes-remote-support-receiver-wormhole-helper
+++ b/qubes-remote-support-receiver-wormhole-helper
@@ -3,22 +3,4 @@
 set -x
 set -e
 
-if command -v wormhole >/dev/null ; then
-    ## wormhole available in dom0 (Qubes R4.1)
-    wormhole send --code-length=4 "$1"
-    exit
-fi
-
-## wormhole not available in dom0 (Qubes R4.0)
-
-qvm-run \
-    --verbose \
-    --autostart \
-    --dispvm whonix-ws-15-dvm \
-    --pass-io \
-    -- \
-    'set -eu
-mkdir /tmp/qubes-remote-support
-cat > /tmp/qubes-remote-support/remote-support-keys.tar.gz
-exec wormhole send --code-length=4 /tmp/qubes-remote-support/remote-support-keys.tar.gz
-' < "$1"
+wormhole send --code-length=4 "$1"


### PR DESCRIPTION
I suppose latest git master can always reflect the latest Qubes development state and that stabilized code such as for Qubes R4.0 support would go into separate branches in case of a Qubes R4.0 security update is required (very unlikely in this case, I suppose).

Therefore removing Qubes R4.0 legacy support code to simplify code and reduce confusion.

https://forum.qubes-os.org/t/qubes-remote-support-new-features-and-support-for-whonix-16/11819
